### PR TITLE
Switch from go-etcd to etcd/client

### DIFF
--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -2,10 +2,10 @@ package kvwrapper_etcd
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/behance/go-common/kvwrapper"
+	log "github.com/behance/go-logging/log"
 	etcd "github.com/coreos/etcd/client"
 )
 
@@ -36,6 +36,7 @@ func (e EtcdWrapper) Set(key string, val string, ttl uint64) error {
 	}
 	_, err := e.kapi.Set(context.Background(), key, val, options)
 	if err != nil {
+		log.Warn("Could not set key in etcd.", "key", key, "err", err)
 		return err
 	}
 	return nil
@@ -51,9 +52,9 @@ func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 	if err != nil {
 		if etcd.IsKeyNotFound(err) {
 			return nil, kvwrapper.ErrKeyNotFound
-		} else {
-			return nil, kvwrapper.ErrCouldNotConnect
 		}
+		log.Warn("Could not retrieve key from etcd.", "key", key, "err", err)
+		return nil, kvwrapper.ErrCouldNotConnect
 	}
 	kv := &kvwrapper.KeyValue{
 		Key:         key,
@@ -63,7 +64,7 @@ func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 	return kv, nil
 }
 
-// GetVal returns a []KeyValue found at key
+// GetList returns a []KeyValue found at key
 func (e EtcdWrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, error) {
 	options := &etcd.GetOptions{
 		Sort:      sort,
@@ -73,9 +74,9 @@ func (e EtcdWrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, erro
 	if err != nil {
 		if etcd.IsKeyNotFound(err) {
 			return nil, kvwrapper.ErrKeyNotFound
-		} else {
-			return nil, kvwrapper.ErrCouldNotConnect
 		}
+		log.Warn("Could not retrieve key from etcd.", "key", key, "err", err)
+		return nil, kvwrapper.ErrCouldNotConnect
 	}
 	kvs := make([]*kvwrapper.KeyValue, 0)
 	for i := 0; i < r.Node.Nodes.Len(); i++ {

--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -45,7 +45,7 @@ func (e EtcdWrapper) Set(key string, val string, ttl uint64) error {
 func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 	options := &etcd.GetOptions{
 		Sort:      false,
-		Recursive: true,
+		Recursive: false,
 	}
 	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {

--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -54,7 +54,7 @@ func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 			return nil, kvwrapper.ErrKeyNotFound
 		}
 		log.Warn("Could not retrieve key from etcd.", "key", key, "err", err)
-		return nil, kvwrapper.ErrCouldNotConnect
+		return nil, err
 	}
 	kv := &kvwrapper.KeyValue{
 		Key:         key,
@@ -76,7 +76,7 @@ func (e EtcdWrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, erro
 			return nil, kvwrapper.ErrKeyNotFound
 		}
 		log.Warn("Could not retrieve key from etcd.", "key", key, "err", err)
-		return nil, kvwrapper.ErrCouldNotConnect
+		return nil, err
 	}
 	kvs := make([]*kvwrapper.KeyValue, 0)
 	for i := 0; i < r.Node.Nodes.Len(); i++ {

--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -49,7 +49,7 @@ func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 	}
 	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "100:") {
+		if etcd.IsKeyNotFound(err) {
 			return nil, kvwrapper.ErrKeyNotFound
 		} else {
 			return nil, kvwrapper.ErrCouldNotConnect
@@ -71,7 +71,7 @@ func (e EtcdWrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, erro
 	}
 	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "100:") {
+		if etcd.IsKeyNotFound(err) {
 			return nil, kvwrapper.ErrKeyNotFound
 		} else {
 			return nil, kvwrapper.ErrCouldNotConnect

--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -1,29 +1,40 @@
 package kvwrapper_etcd
 
 import (
+	"context"
 	"strings"
+	"time"
 
 	"github.com/behance/go-common/kvwrapper"
-	"github.com/coreos/go-etcd/etcd"
+	etcd "github.com/coreos/etcd/client"
 )
 
 // EtcdWrapper wraps the go-etcd client so it can implement the KVWrapper interface
 type EtcdWrapper struct {
-	client *etcd.Client
+	kapi etcd.KeysAPI
 }
 
 // NewKVWrapper returns a new kvwrapper_etcd as a KVWrapper
 func (e EtcdWrapper) NewKVWrapper(servers []string, username, password string) kvwrapper.KVWrapper {
-	e.client = etcd.NewClient(servers)
-	if username != "" && password != "" {
-		e.client.SetCredentials(username, password)
+	config := etcd.Config{
+		Endpoints: servers,
+		Transport: etcd.DefaultTransport,
+		Username:  username,
+		Password:  password,
 	}
-	return e
+	client, err := etcd.New(config)
+	if err != nil {
+		panic(err)
+	}
+	return EtcdWrapper{kapi: etcd.NewKeysAPI(client)}
 }
 
-//Set stes the key = val with a ttl of ttl. If key is a path, it will be created.
+// Set sets the key = val with a ttl of ttl. If key is a path, it will be created.
 func (e EtcdWrapper) Set(key string, val string, ttl uint64) error {
-	_, err := e.client.Set(key, val, ttl)
+	options := &etcd.SetOptions{
+		TTL: time.Duration(ttl) * time.Second,
+	}
+	_, err := e.kapi.Set(context.Background(), key, val, options)
 	if err != nil {
 		return err
 	}
@@ -32,7 +43,11 @@ func (e EtcdWrapper) Set(key string, val string, ttl uint64) error {
 
 // GetVal returns a single KeyValue found at key
 func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
-	r, err := e.client.Get(key, false, true)
+	options := &etcd.GetOptions{
+		Sort:      false,
+		Recursive: true,
+	}
+	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "501:") {
 			return nil, kvwrapper.ErrCouldNotConnect
@@ -52,7 +67,11 @@ func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 
 // GetVal returns a []KeyValue found at key
 func (e EtcdWrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, error) {
-	r, err := e.client.Get(key, sort, true)
+	options := &etcd.GetOptions{
+		Sort:      sort,
+		Recursive: true,
+	}
+	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "501:") {
 			return nil, kvwrapper.ErrCouldNotConnect

--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -49,12 +49,10 @@ func (e EtcdWrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
 	}
 	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "501:") {
-			return nil, kvwrapper.ErrCouldNotConnect
-		} else if strings.HasPrefix(err.Error(), "100:") {
+		if strings.HasPrefix(err.Error(), "100:") {
 			return nil, kvwrapper.ErrKeyNotFound
 		} else {
-			return nil, err
+			return nil, kvwrapper.ErrCouldNotConnect
 		}
 	}
 	kv := &kvwrapper.KeyValue{
@@ -73,12 +71,10 @@ func (e EtcdWrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, erro
 	}
 	r, err := e.kapi.Get(context.Background(), key, options)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "501:") {
-			return nil, kvwrapper.ErrCouldNotConnect
-		} else if strings.HasPrefix(err.Error(), "100:") {
+		if strings.HasPrefix(err.Error(), "100:") {
 			return nil, kvwrapper.ErrKeyNotFound
 		} else {
-			return nil, err
+			return nil, kvwrapper.ErrCouldNotConnect
 		}
 	}
 	kvs := make([]*kvwrapper.KeyValue, 0)


### PR DESCRIPTION
because the former is deprecated and hasn't been updated in years.

I wonder if we're hitting bugs in the client that have already been fixed.

Note that a possible future direction is to migrate off `go-common/kvwrapper` entirely and use a more powerful KV abstraction like [libkv](https://github.com/docker/libkv) -- see https://github.com/adobe-community/issues-ethos/issues/4329

Issue: https://github.com/adobe-community/issues-ethos/issues/4236

Cc: @iderdik, @jimmyislive, @seanisom, @matthewdfuller, @bryanlatten 