### PR TITLE
Etcd v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 capcom-v*
 Godeps/_workspace/*
 Godeps/Readme
+vendor/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 * KV-Wrapper wraps the go-etcd client so it can implement the KVWrapper interface
 * KVWrapper is an interface that any Key Value Store (etcd, consul) needs to implement when used by flight director.
-* Log is a wrapper for go-logrus forked from [logrus](https://github.com/Sirupsen/logrus) It servers 2 main purposes:
+* KVWrapper currently supports etcd-v2 and partially supports etcd-v3, limited to the existing interface
+* In particular, the limitation means that there is no way to modify a key/value with a ttl, to remove the ttl completely.  In v2 that happens by modifying the ttl value to 0; however, v3 handles ttl, under the hood, with leases, and the initial implementation doesn't keep track of the leases. It is important to note, that there is no existinguse case that depends on this capability.
+* Log is a wrapper for go-logrus forked from [logrus](https://github.com/Sirupsen/logrus) It serves 2 main purposes:
   - It eliminates the need for awkward .WithFields calls by intelligently creating fields
   based on the number and positions of parameters to the Warn, Error, Fatal and Info calls.
   - It adds stack info to ever call for easier debugging

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 81b912769441b5eedd1b607f4f0ceafe0360fcaa2608923c08f356503be54d64
-updated: 2018-05-14T14:24:27.964346485-07:00
+hash: 5fdf6f92e35acb1c946ec9fdfe4a67cd8bb5aa9708d4ce98436b582d094e1cb7
+updated: 2018-05-18T14:12:28.259236-04:00
 imports:
 - name: github.com/behance/go-logging
   version: 98df59751f14b46c6391ee33e0a3d3888708f54b
@@ -10,25 +10,44 @@ imports:
 - name: github.com/codegangsta/negroni
   version: 5dbbc83f748fc3ad38585842b0aedab546d0ea1e
 - name: github.com/coreos/etcd
-  version: 70c8726202dd91e482fb4029fd14af1d4ed1d5af
+  version: ~v3.3.8
   subpackages:
+  - auth/authpb
   - client
+  - clientv3
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - mvcc/mvccpb
   - pkg/pathutil
   - pkg/srv
   - pkg/types
   - version
 - name: github.com/coreos/go-semver
-  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
   - semver
+- name: github.com/gogo/protobuf
+  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
+  subpackages:
+  - gogoproto
+  - proto
+  - protoc-gen-gogo/descriptor
+- name: github.com/golang/protobuf
+  version: 9f81198da99b79e14d70ca2c3cc1bbe44c6e69b6
+  subpackages:
+  - jsonpb
+  - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/PuerkitoBio/rehttp
   version: 5989d9566be1c6334786e55385219c2b9ab1c4dc
 - name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  version: f3cacc17c85ecb7f1b6a9e373ee85d1480919868
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
+  version: db08ff08e8622530d9ed3a0e8ac279f6d4c02196
   subpackages:
   - context
   - html
@@ -36,8 +55,56 @@ imports:
   - html/charset
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
+  - lex/httplex
   - trace
+- name: golang.org/x/text
+  version: b19bf474d317b857955b12035d2c5acb57ce8b01
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: b28608a9dbfcc585a10c13222c50cfeb50b7ac7a
+  subpackages:
+  - balancer
+  - codes
+  - connectivity
+  - credentials
+  - grpclb/grpc_lb_v1/messages
+  - grpclog
+  - health
+  - health/grpc_health_v1
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - stats
+  - status
+  - tap
+  - transport
 testImports:
 - name: github.com/onsi/ginkgo
   version: fa5fabab2a1bfbd924faf4c067d07ae414e2aedf
@@ -74,28 +141,8 @@ testImports:
   - matchers/support/goraph/util
   - types
 - name: golang.org/x/sys
-  version: e48874b42435b4347fc52bdee0424a52abc974d7
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
-- name: golang.org/x/text
-  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
-  subpackages:
-  - encoding
-  - encoding/charmap
-  - encoding/htmlindex
-  - encoding/internal
-  - encoding/internal/identifier
-  - encoding/japanese
-  - encoding/korean
-  - encoding/simplifiedchinese
-  - encoding/traditionalchinese
-  - encoding/unicode
-  - internal/language
-  - internal/language/compact
-  - internal/tag
-  - internal/utf8internal
-  - language
-  - runes
-  - transform
 - name: gopkg.in/yaml.v2
   version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,9 +8,10 @@ import:
 - package: github.com/codegangsta/negroni
   version: ^0.2.0
 - package: github.com/coreos/etcd
-  version: ^3.2.0-rc.1
+  version: ~v3.3.8
   subpackages:
   - client
+  - clientv3
 - package: github.com/PuerkitoBio/rehttp
 testImport:
 - package: github.com/onsi/ginkgo

--- a/kvwrapper_etcd_v3/kvwrapper_etcd_v3.go
+++ b/kvwrapper_etcd_v3/kvwrapper_etcd_v3.go
@@ -1,0 +1,173 @@
+package kvwrapper_etcd_v3
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/behance/go-common/kvwrapper"
+	log "github.com/behance/go-logging/log"
+	etcdv3 "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+)
+
+// EtcdWrapper wraps the go-etcd client so it can implement the KVWrapper interface
+type EtcdV3Wrapper struct {
+	kapi etcdv3.KV
+	cli  etcdv3.Client
+}
+
+// NewKVWrapper returns a new kvwrapper_etcd as a KVWrapper
+func (e EtcdV3Wrapper) NewKVWrapper(servers []string, username, password string) kvwrapper.KVWrapper {
+	config := etcdv3.Config{
+		Endpoints:   servers,
+		Username:    username,
+		Password:    password,
+		DialTimeout: 5 * time.Second,
+	}
+	client, err := etcdv3.New(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return EtcdV3Wrapper{kapi: etcdv3.NewKV(client), cli: *client}
+}
+
+// Set sets the key = val with a ttl of ttl. If key is a path, it will be created.
+// The ttl will be handled via a lease
+// Leases are given in increments of seconds, and leases are granted in increments of seconds,
+// hence there is no need to convert to time.Duration (which is in nanoseconds) as is done in version 2
+// note! The API assumes that a ttl of 0, implies a wish that the key/value pair not expire
+// implementing that behavior in v3, by not acquiring a lease
+func (e EtcdV3Wrapper) Set(key string, val string, ttl uint64) error {
+	// acquire a lease to which we'll attach the new key/value pair
+	// lease.grant takes an int64 as the ttl, hence casting is necessary
+	log.Debug("called Set with key/value: ", key, val, " and ttl ", ttl)
+	if ttl == 0 {
+		_, put_err := e.kapi.Put(context.Background(), key, val)
+		if put_err != nil {
+			log.Warn("Could not set key in etcd.", "key", key, "err", put_err)
+			return put_err
+		}
+	} else {
+		lease, lease_err := e.cli.Grant(context.Background(), int64(ttl))
+		if lease_err != nil {
+			log.Fatal(lease_err)
+			return lease_err
+		}
+
+		log.Debug("go-common: Set - got lease", lease.ID, " with a ttl of ", lease.TTL)
+		// Insert key with a lease of ttl second TTL
+		_, put_err := e.kapi.Put(context.Background(), key, val, etcdv3.WithLease(lease.ID))
+		if put_err != nil {
+			log.Warn("Could not set key in etcd.", "key", key, "err", put_err)
+			// if the Put op failed, clean up the lease
+			_, revoke_err := e.cli.Revoke(context.Background(), lease.ID)
+			if revoke_err != nil {
+				log.Warn("Attempt to revoke lease failed with error ", revoke_err, " for lease.ID ", lease.ID)
+			}
+			return put_err
+		}
+	}
+	return nil
+}
+
+// GetVal returns a single KeyValue found at key
+func (e EtcdV3Wrapper) GetVal(key string) (*kvwrapper.KeyValue, error) {
+	// by default no sorting nor range expansion is performed
+	log.Debug("entering GetVal with key ", key)
+
+	r, err := e.kapi.Get(context.Background(), key)
+	if err != nil {
+		if err == context.Canceled {
+			log.Warn("Context Cancelled could not retrieve key ", key, " receiving error ", err)
+			return nil, err
+			// else if handles case grpc.ErrClientConnClosing by checking if message contains "client"
+		} else if strings.Contains(err.Error(), "client") {
+			log.Warn("Client Connection Closed - could not retrieve key ", key, " receiving error ", err)
+			return nil, err
+		}
+	}
+	if err != nil || r.Kvs == nil || len(r.Kvs) < 1 {
+		log.Info("could not retrieve key ", key, " receiving error ", err)
+		if err == rpctypes.ErrKeyNotFound || r.Kvs == nil || len(r.Kvs) == 0 {
+			return nil, kvwrapper.ErrKeyNotFound
+		}
+		log.Warn("Could not retrieve key from etcd.", "key", key, "err", err)
+		return nil, err
+	}
+
+	kv := &kvwrapper.KeyValue{
+		Key:         key,
+		Value:       string(r.Kvs[0].Value),
+		HasChildren: false,
+	}
+	return kv, nil
+}
+
+// GetList returns a[]KeyValue found whose keys all begin with key as prefix
+func (e EtcdV3Wrapper) GetList(key string, sort bool) ([]*kvwrapper.KeyValue, error) {
+	options := []etcdv3.OpOption{
+		etcdv3.WithSort(etcdv3.SortByKey, etcdv3.SortAscend),
+		etcdv3.WithPrefix(),
+	}
+	r, err := e.kapi.Get(context.Background(), key, options...)
+	if err != nil {
+		if err == rpctypes.ErrKeyNotFound {
+			return nil, kvwrapper.ErrKeyNotFound
+		}
+		log.Warn("Could not retrieve key from etcd.", "key", key, "err", err)
+		return nil, err
+	}
+	kvs := make([]*kvwrapper.KeyValue, 0)
+	num_kv := len(r.Kvs)
+	for i := 0; i < num_kv; i++ {
+		kv := &kvwrapper.KeyValue{
+			Key:         string(r.Kvs[i].Key),
+			Value:       string(r.Kvs[i].Value),
+			HasChildren: false,
+		}
+		kvs = append(kvs, kv)
+	}
+	return kvs, nil
+}
+
+// delete individual key
+// is candidate to be added to interface
+func Delete(e EtcdV3Wrapper, key string) error {
+	// by default no sorting nor range expansion is performed
+	r, err := e.kapi.Delete(context.Background(), key)
+	if err != nil {
+		if err == rpctypes.ErrKeyNotFound {
+			return kvwrapper.ErrKeyNotFound
+		}
+		log.Warn("Could not delete key from etcd.", "key", key, "err", err)
+		return err
+	} else if r.Deleted == 0 {
+		return kvwrapper.ErrKeyNotFound
+	}
+
+	return nil
+}
+
+// delete all keys beginning with this prefix
+// returns the number of key/value pairs that were deleted
+// is candidate to be added to interface
+func DeleteList(e EtcdV3Wrapper, key string) (int64, error) {
+	options := []etcdv3.OpOption{
+		etcdv3.WithPrefix(),
+	}
+	// by default no sorting nor range expansion is performed
+	r, err := e.kapi.Delete(context.Background(), key, options...)
+	if err != nil {
+		if err == rpctypes.ErrKeyNotFound {
+			return r.Deleted, kvwrapper.ErrKeyNotFound
+		}
+		log.Warn("Could not delete key from etcd.", "key", key, "err", err)
+		return r.Deleted, err
+	} else if r.Deleted == 0 {
+		return r.Deleted, kvwrapper.ErrKeyNotFound
+	}
+
+	return r.Deleted, nil
+}

--- a/kvwrapper_etcd_v3/kvwrapper_etcd_v3_test.go
+++ b/kvwrapper_etcd_v3/kvwrapper_etcd_v3_test.go
@@ -1,0 +1,200 @@
+package kvwrapper_etcd_v3
+
+// package kvwrapper_etcd_v3
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/behance/go-common/kvwrapper"
+	"github.com/behance/go-common/log"
+)
+
+func TestGetSingle(t *testing.T) {
+	if os.Getenv("KV_ETCD_LOCALHOST") == "" {
+		t.Skip("skipping test; $KV_ETCD_LOCALHOST not set")
+	}
+	hosts := []string{"http://localhost:2379"}
+	kvw := kvwrapper.NewKVWrapperWithAuth(
+		hosts,
+		EtcdV3Wrapper{},
+		"", // cfg.KVUsername,
+		"", // cfg.KVPassword,
+	)
+
+	set_err := kvw.Set("Foo", "Bar", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "Foo", "Value", "Bar", " With error: ", set_err)
+		t.Error("Failed to create Foo:Bar as Key:Value pair")
+		return
+	}
+	kv_pair, get_err := kvw.GetVal("Foo")
+	if get_err != nil {
+		log.Warn("Expected to get", "Bar", " But got error: ", get_err)
+		t.Error("failed to retrieve newly created Foo:Bar key:value pair")
+		return
+	}
+	if kv_pair.Value != "Bar" {
+		log.Warn("We expected to get ", "Bar", " but we got: ", kv_pair.Value)
+		t.Error("Expected Bar, got ", kv_pair.Value)
+		return
+	}
+	set_err = kvw.Set("FooShortTTL", "Bar", 0)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "FooShortTTL", "Value", "Bar", " With error: ", set_err)
+		t.Error("Failed to create FooShortTTL:Bar as Key:Value pair")
+		return
+	}
+	kv_pair, get_err = kvw.GetVal("FooShortTTL")
+	if get_err != nil {
+		log.Warn("Expected to get", "Bar", " But got error: ", get_err)
+		t.Error("failed to retrieve newly created FooShortTTL:Bar key:value pair")
+		return
+	}
+	kv_pair, get_err = kvw.GetVal("FooFoo")
+	if get_err != nil {
+		log.Info("Expected to get an error because key FooFoo doesn't exist ", "And got error: ", get_err)
+	}
+	if kv_pair != nil && kv_pair.Value != "" {
+		log.Warn("We expected to get nil", " but we got: ", kv_pair.Value)
+		t.Error("Expected nil, got ", kv_pair.Value)
+		return
+	}
+}
+
+func TestGetMultiple(t *testing.T) {
+	if os.Getenv("KV_ETCD_LOCALHOST") == "" {
+		t.Skip("skipping test; $KV_ETCD_LOCALHOST not set")
+	}
+	hosts := []string{"http://localhost:2379"}
+	kvw := EtcdV3Wrapper.NewKVWrapper(EtcdV3Wrapper{}, hosts, "", "")
+
+	set_err := kvw.Set("Foo/1", "Bar/1", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "Foo/2", "Value", "Bar/2", " With error: ", set_err)
+		t.Error("Failed to add Foo/1:Bar/1 as key:value pair")
+		return
+	}
+	set_err = kvw.Set("Foo/2", "Bar/2", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "Foo/2", "Value", "Bar/2", " With error: ", set_err)
+		t.Error("Failed to add Foo/2:Bar/2 as key:value pair")
+		return
+	}
+	set_err = kvw.Set("Foo/3", "Bar/3", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "Foo/3", "Value", "Bar/3", " With error: ", set_err)
+		t.Error("Failed to add Foo/3:Bar/3 as key:value pair")
+		return
+	}
+
+	kv_pairs, get_err := kvw.GetList("Foo/", false)
+	if get_err != nil || len(kv_pairs) != 3 {
+		log.Warn("Expected to get 3 key/value pairs but got ", len(kv_pairs), " error: ", get_err)
+		t.Error("Expected 3 entries, got none")
+		return
+	}
+
+	for _, ev := range kv_pairs {
+		log.Debug(fmt.Sprintf("%s : %s\n", ev.Key, ev.Value))
+	}
+
+}
+
+func TestDelSingle(t *testing.T) {
+	if os.Getenv("KV_ETCD_LOCALHOST") == "" {
+		t.Skip("skipping test; $KV_ETCD_LOCALHOST not set")
+	}
+	hosts := []string{"http://localhost:2379"}
+	kvw := EtcdV3Wrapper.NewKVWrapper(EtcdV3Wrapper{}, hosts, "", "")
+
+	kv_pairs, get_err := kvw.GetList("", false)
+	num_entries := 0
+	if get_err != nil && get_err != kvwrapper.ErrKeyNotFound {
+		log.Warn("GetList failed for to retrieve anything with error: ", get_err)
+	} else {
+		num_entries = len(kv_pairs)
+	}
+	if num_entries == 0 {
+		del_err := Delete(kvw.(EtcdV3Wrapper), "Foo")
+		if del_err == nil || del_err != kvwrapper.ErrKeyNotFound {
+			log.Warn("Expected to get error that key isn't found but got ", del_err)
+			t.Error("delete of Foo succeeded even though it wasn't supposed to be in key/value store")
+			return
+		}
+	}
+
+	set_err := kvw.Set("Foo", "Bar", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "Foo", "Value", "Bar", " With error: ", set_err)
+		return
+	}
+
+	del_err := Delete(kvw.(EtcdV3Wrapper), "Foo")
+	if del_err != nil {
+		log.Warn("Expected delete of key Foo to succeed but got error: ", del_err)
+		t.Error("Delete of Foo failed")
+		return
+	} else {
+		log.Debug("Deleted key Foo")
+	}
+
+}
+
+func TestDelMultiple(t *testing.T) {
+	if os.Getenv("KV_ETCD_LOCALHOST") == "" {
+		t.Skip("skipping test; $KV_ETCD_LOCALHOST not set")
+	}
+	hosts := []string{"http://localhost:2379"}
+	kvw := EtcdV3Wrapper.NewKVWrapper(EtcdV3Wrapper{}, hosts, "", "")
+
+	kv_pairs, get_err := kvw.GetList("", false)
+	var num_entries int64
+	num_entries = 0
+	if get_err != nil && get_err != kvwrapper.ErrKeyNotFound {
+		log.Warn("GetList failed for to retrieve anything with error: ", get_err)
+	} else {
+		num_entries = int64(len(kv_pairs))
+	}
+	set_err := kvw.Set("/DelMult/Foo/1", "Bar/1", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "/DelMult/Foo/1", "Value", "Bar/2", " With error: ", set_err)
+		return
+	}
+	set_err = kvw.Set("/DelMult/Foo/2", "Bar/2", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "/DelMult/Foo/2", "Value", "Bar/2", " With error: ", set_err)
+		return
+	}
+	set_err = kvw.Set("/DelMult/Foo/3", "Bar/3", 30)
+	if set_err != nil {
+		log.Warn("Set failed for ", "key", "/DelMultFoo/3", "Value", "Bar/3", " With error: ", set_err)
+		return
+	}
+
+	kv_pairs, get_err = kvw.GetList("/DelMult", false)
+	if get_err != nil || len(kv_pairs) != 3 {
+		num_ent := 0
+		if kv_pairs != nil {
+			num_ent = len(kv_pairs)
+		}
+		log.Warn("Expected to get 3 key/value pairs but got ", num_ent, " error: ", get_err)
+		t.Error("Expected 3 entries, got ", num_ent)
+		return
+	} else {
+		num_entries = int64(len(kv_pairs))
+	}
+
+	for _, ev := range kv_pairs {
+		log.Debug(fmt.Sprintf("%s : %s\n", ev.Key, ev.Value))
+	}
+	num_dels, del_err := DeleteList(kvw.(EtcdV3Wrapper), "/DelMult")
+	log.Debug("delete list returns: ", num_dels, " as number of elements deleted")
+	if del_err != nil || num_dels != num_entries {
+		log.Warn("Expected to get ", num_entries, " but got ", num_dels, " entries and error ", del_err)
+		t.Error("didn't delete expected number of entries")
+	} else {
+		log.Debug("Deleted ", num_entries)
+	}
+
+}


### PR DESCRIPTION
adobe-community/issues-ethos#13414

The tests run during CI fail because no etcd servers are present.  However, when the v3 tests run manually against a local etcd server they pass, as seen in the included output:

pinchass-mbp:kvwrapper_etcd_v3 lev$ go test -v ./...
=== RUN   TestGetSingle
time="2018-06-29T14:47:49-04:00" level=info msg=  receiving error =<nil> caller="kvwrapper_etcd_v3.EtcdV3Wrapper.GetVal:97 | kvwrapper_etcd_v3.TestGetSingle:58" could not retrieve key =FooFoo file="kvwrapper_etcd_v3.go" 
time="2018-06-29T14:47:49-04:00" level=info msg="Expected to get an error because key FooFoo doesn't exist " And got error: ="Key not found" caller="kvwrapper_etcd_v3.TestGetSingle:60 | testing.tRunner:777" file="kvwrapper_etcd_v3_test.go" 
--- PASS: TestGetSingle (0.02s)
=== RUN   TestGetMultiple
--- PASS: TestGetMultiple (0.02s)
=== RUN   TestDelSingle
--- PASS: TestDelSingle (0.01s)
=== RUN   TestDelMultiple
--- PASS: TestDelMultiple (0.02s)
PASS
ok  	github.com/PinchasLev/go-common/kvwrapper_etcd_v3	3.469s
