### PR TITLE
library no longer panics if underlying etcd client cannot be created,…

### DIFF
--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -24,7 +24,8 @@ func (e EtcdWrapper) NewKVWrapper(servers []string, username, password string) k
 	}
 	client, err := etcd.New(config)
 	if err != nil {
-		panic(err)
+		log.Fatal("Could not instantiate etcd V2 client.", "err", err)
+		return nil
 	}
 	return EtcdWrapper{kapi: etcd.NewKeysAPI(client)}
 }

--- a/kvwrapper_etcd_v3/kvwrapper_etcd_v3.go
+++ b/kvwrapper_etcd_v3/kvwrapper_etcd_v3.go
@@ -27,7 +27,8 @@ func (e EtcdV3Wrapper) NewKVWrapper(servers []string, username, password string)
 	}
 	client, err := etcdv3.New(config)
 	if err != nil {
-		panic(err)
+		log.Fatal("Could not instantiate etcd V3 client.", "err", err)
+		return nil
 	}
 
 	return EtcdV3Wrapper{kapi: etcdv3.NewKV(client), cli: *client}


### PR DESCRIPTION
when underlying etcd client fails to instantiate object, returns nil instead of panicking