### PR TITLE
corrected log level to Warn, so as not to os.Exit(1), when etcd clien…

### DIFF
--- a/kvwrapper_etcd/kvwrapper_etcd.go
+++ b/kvwrapper_etcd/kvwrapper_etcd.go
@@ -24,7 +24,8 @@ func (e EtcdWrapper) NewKVWrapper(servers []string, username, password string) k
 	}
 	client, err := etcd.New(config)
 	if err != nil {
-		log.Fatal("Could not instantiate etcd V2 client.", "err", err)
+		// even though this is a critical error, wedon't want to issue log.Fatal, since that would os.Exit(1) from within the lib
+		log.Warn("Could not instantiate etcd V2 client.", "err", err)
 		return nil
 	}
 	return EtcdWrapper{kapi: etcd.NewKeysAPI(client)}

--- a/kvwrapper_etcd_v3/kvwrapper_etcd_v3.go
+++ b/kvwrapper_etcd_v3/kvwrapper_etcd_v3.go
@@ -27,7 +27,8 @@ func (e EtcdV3Wrapper) NewKVWrapper(servers []string, username, password string)
 	}
 	client, err := etcdv3.New(config)
 	if err != nil {
-		log.Fatal("Could not instantiate etcd V3 client.", "err", err)
+		// even though this is a critical error, wedon't want to issue log.Fatal, since that would os.Exit(1) from within the lib
+		log.Warn("Could not instantiate etcd V3 client.", "err", err)
 		return nil
 	}
 


### PR DESCRIPTION
#12 log a warning when the underlying etcd client cannot instantiate an object and return nil.  log.Fatal causes the library to exit.